### PR TITLE
Fix broken lua lsp package

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -31,7 +31,7 @@
     vimdiffAlias = true;
 
     extraPackages = with pkgs; [
-      luajitPackages.lua-lsp
+      lua-language-server
       rnix-lsp
 
       xclip


### PR DESCRIPTION
luajitPackages.lua-lsp doesn't work and is out of date for lua anyway.
lua-language-server is the more official version that is well supported